### PR TITLE
Fix incorrect filtering instruction in Slice3 exercise

### DIFF
--- a/exercises/slices/slice3.nr
+++ b/exercises/slices/slice3.nr
@@ -6,7 +6,7 @@
 fn transform_slice(input: [Field]) -> [Field] {
     // TODO:
     // 1. Double each element in the slice using map
-    // 2. Filter out all elements that are greater than 10
+    // 2. Filter out all elements that are less than 10
     // 3. Return the resulting slice
 
     // Your code here

--- a/info.toml
+++ b/info.toml
@@ -255,7 +255,7 @@ hint = """
 ```
     let slice1 = input.map(|a| a * 2);
 ```
-2. Filter elements greater than 10 using `filter method`
+2. Filter elements less than 10 using `filter method`
 ```
     let slice2 = slice1.filter(|a| a as u64 <= 10);
 ```


### PR DESCRIPTION
This PR fixes #4 an incorrect instruction in the Slice3 exercise where the comment states to "Filter out all elements that are greater than 10" but the actual implementation and tests expect filtering to keep elements less than or equal to 10.

Changes made:
1. Updated the instruction comment in `exercises/slices/slice3.nr` to correctly state "Filter out all elements that are less than 10"
2. Fixed the same issue in the corresponding `info.toml` file

This change ensures that the instructions align with the actual code implementation and test expectations.

